### PR TITLE
healthinfo bug fix

### DIFF
--- a/src/inc/pmw_comm.h
+++ b/src/inc/pmw_comm.h
@@ -109,7 +109,7 @@ struct HEALTH_INFO_PAGE_NODE_S {
     unsigned char rsvd2;
     unsigned char media_temp[2];
     unsigned char controller_temp[2];
-    unsigned char rsvd3[12];
+    unsigned char rsvd3[16];
     unsigned char vendor_data_size[4];
     unsigned char rsvd4[8];
     unsigned char power_on_time[8];

--- a/src/inc/pmw_version.h
+++ b/src/inc/pmw_version.h
@@ -32,7 +32,7 @@
 #define PRODUCT_NAME   "Intel(R) PMWatch"
 
 #define MAJOR_VERSION  3
-#define MINOR_VERSION  0
+#define MINOR_VERSION  2
 #define UPDATE_VERSION 0
 #if UPDATE_VERSION > 0
 #define UPDATE_STRING  " Update "STRINGIFY(UPDATE_VERSION)


### PR DESCRIPTION
Fixed incorrect health info output buffer struct.
Incremented the version to 3.2.