### PR TITLE
update build-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,21 +46,18 @@ PMWatch is dependent on [libipmctl](https://github.com/intel/ipmctl).
 Perform the following steps to install the tool dependencies.
 
 #### Fedora
-> $ yum install daxctl-devel.x86_64 ndctl-devel.x86_64 libipmctl-devel.x86_64 libsafec-devel.x86_64
+> $ yum install daxctl-devel.x86_64 ndctl-devel.x86_64 libipmctl-devel.x86_64
 
 #### CentOS, RHEL
 > $ wget https://copr-be.cloud.fedoraproject.org/results/jhli/ipmctl/epel-7-x86_64/00874029-ipmctl/libipmctl-devel-02.00.00.3446-1.el7.x86_64.rpm<br/>
-> $ wget https://copr-be.cloud.fedoraproject.org/results/jhli/safeclib/epel-7-x86_64/00773240-libsafec/libsafec-03032018-2.0.g570fa5.el7.x86_64.rpm<br/>
 > $ yum install ndctl-libs.x86_64<br/>
-> $ rpm -ivh libipmctl-devel-02.00.00.3446-1.el7.x86_64.rpm libsafec-03032018-2.0.g570fa5.el7.x86_64.rpm
+> $ rpm -ivh libipmctl-devel-02.00.00.3446-1.el7.x86_64.rpm
 
 #### Ubuntu
 * Download appropriate *libdaxctl-dev_\*.deb* https://packages.ubuntu.com/search?keywords=daxctl-dev.
 * Download appropriate *libndctl-dev_\*.deb* package from https://packages.ubuntu.com/search?keywords=ndctl-dev.
 * Download appropriate *libipmctl-dev_\*.deb* package from https://packages.ubuntu.com/search?keywords=libipmctl-dev.
 
-> $ wget http://ppa.launchpad.net/jhli/libsafec/ubuntu/pool/main/libs/libsafec/libsafec3_3.3-1_amd64.deb<br/>
-> $ dpkg -i libsafec3_3.3-1_amd64.deb<br/>
 > $ dpkg -i libdaxctl-dev_\*.deb<br/>
 > $ dpkg -i libndctl-dev_\*.deb<br/>
 > $ dpkg -i libipmctl-dev_\*.deb

--- a/README.md
+++ b/README.md
@@ -53,14 +53,8 @@ Perform the following steps to install the tool dependencies.
 > $ yum install ndctl-libs.x86_64<br/>
 > $ rpm -ivh libipmctl-devel-02.00.00.3446-1.el7.x86_64.rpm
 
-#### Ubuntu
-* Download appropriate *libdaxctl-dev_\*.deb* https://packages.ubuntu.com/search?keywords=daxctl-dev.
-* Download appropriate *libndctl-dev_\*.deb* package from https://packages.ubuntu.com/search?keywords=ndctl-dev.
-* Download appropriate *libipmctl-dev_\*.deb* package from https://packages.ubuntu.com/search?keywords=libipmctl-dev.
-
-> $ dpkg -i libdaxctl-dev_\*.deb<br/>
-> $ dpkg -i libndctl-dev_\*.deb<br/>
-> $ dpkg -i libipmctl-dev_\*.deb
+#### Ubuntu, Debian
+> $ apt install libdaxctl-dev libndctl-dev libipmctl-dev
 
 ### Build tools
 Install the following build tools:

--- a/README.md
+++ b/README.md
@@ -58,4 +58,5 @@ Perform the following steps to install the tool dependencies.
 
 ### Build tools
 Install the following build tools:
-> autoconf, automake, flex, bison, libtool, pkg-config
+> autoconf, automake, flex, bison, libtool, pkg-config, libkmod-dev,
+> libudev-dev, uuid-dev

--- a/scripts/install-pmw
+++ b/scripts/install-pmw
@@ -123,23 +123,6 @@ if [ $? -eq 0 ] ; then
     os="ubuntu"
 fi
 
-SYSTEM_LIB64="lib64"
-LIBSAFEC_RPM_URL="https://copr.fedorainfracloud.org/coprs/jhli/safeclib/"
-# RHEL, CentOS: https://copr-be.cloud.fedoraproject.org/results/jhli/safeclib/epel-7-x86_64/00773240-libsafec/ (libsafec-03032018-2.0.g570fa5.el7.x86_64.rpm)
-# Ubuntu: http://ppa.launchpad.net/jhli/libsafec/ubuntu/pool/main/libs/libsafec/
-# Fedora: from system repo or
-# Fedora 28: https://copr-be.cloud.fedoraproject.org/results/jhli/safeclib/fedora-28-x86_64/00773240-libsafec/ (libsafec-03032018-2.0.g570fa5.fc28.x86_64.rpm)
-# Fedora 27: https://copr-be.cloud.fedoraproject.org/results/jhli/safeclib/fedora-27-x86_64/00773240-libsafec/ (libsafec-03032018-2.0.g570fa5.fc27.x86_64.rpm)
-# may be devel packages too
-if [ "${os}" = "ubuntu" ] ; then
-    SYSTEM_LIB64="usr/lib"
-    LIBSAFEC_RPM_URL="https://launchpad.net/~jhli/+archive/ubuntu/libsafec or http://ppa.launchpad.net/jhli/libsafec/ubuntu/pool/main/libs/libsafec/"
-fi
-if [ "${os}" = "suse" ] ; then
-    SYSTEM_LIB64="usr/lib64"
-    LIBSAFEC_RPM_URL="https://build.opensuse.org/package/show/home:jhli/safeclib"
-fi
-
 # check for missing dependencies
 tmp=`ldd ${INSTALL_DIR}/${BIN_DIR}/pmwatch | grep "not found"`
 if [ $? -eq 0 ] ; then
@@ -150,7 +133,6 @@ if [ $? -eq 0 ] ; then
     echo ""
     echo "Depedency resolution tips:"
     echo "    Install ndctl tool to resolve libndctl.so and libdaxctl.so dependencies."
-    echo "    Install libsafec package from ${LIBSAFEC_RPM_URL} if not available in the system repo."
 
     sudo sh -c "rm -rf ${INSTALL_DIR}"
 


### PR DESCRIPTION
* safeclib is no longer needed
* wget+dpkg are unwieldy and don't handle recursive deps — use apt instead
* libkmod-dev, libudev-dev, uuid-dev were missing