### PR TITLE
Fix warnings and optimize "safe C" string functions.

### DIFF
--- a/src/inc/pmw_utils.h
+++ b/src/inc/pmw_utils.h
@@ -139,16 +139,14 @@ PMW_API NVM_UINT32
 PMW_UTILS_Strncpy_Safe (
     char       *dst,
     size_t      dst_size,
-    const char *src,
-    size_t      count
+    const char *src
 );
 
 PMW_API NVM_UINT32
 PMW_UTILS_Strncat_Safe(
     char       *dst,
     size_t      dst_size,
-    const char *src,
-    size_t      count
+    const char *src
 );
 
 PMW_API void

--- a/src/pmw_collect.c
+++ b/src/pmw_collect.c
@@ -90,7 +90,7 @@ PMW_COLLECT_Set_Global_Vars (
     output_format_two     = l_output_format_two;
     collect_health        = l_collect_health;
 
-    ret_val = STRNCPY_SAFE(DELIMITER, sizeof(DELIMITER), l_delim, strlen(l_delim));
+    ret_val = STRNCPY_SAFE(DELIMITER, sizeof(DELIMITER), l_delim);
 
     return ret_val;
 }
@@ -1224,7 +1224,7 @@ PMW_COLLECT_Start_Collection (
         return 1;
     }
 
-    ret_code = STRNCPY_SAFE(filename, SMALL_STR_LEN, "/dev/null", strlen("/dev/null"));
+    ret_code = STRNCPY_SAFE(filename, SMALL_STR_LEN, "/dev/null");
     if (ret_code != NVM_SUCCESS) {
         pthread_mutex_lock(&buffer_lock);
         collection_done = 1;

--- a/src/pmw_comm.c
+++ b/src/pmw_comm.c
@@ -578,13 +578,13 @@ pmw_comm_Check_PreR_FW (
             free(fw_api_version);
             return 1;
         }
-        status = STRNCPY_SAFE(fw_api_major_ver, sizeof(fw_api_major_ver), token, strlen(token));
+        status = STRNCPY_SAFE(fw_api_major_ver, sizeof(fw_api_major_ver), token);
         if (status != NVM_SUCCESS) {
             free(fw_api_version);
             return status;
         }
         while(token) {
-            status = STRNCPY_SAFE(fw_api_minor_ver, sizeof(fw_api_minor_ver), token, strlen(token));
+            status = STRNCPY_SAFE(fw_api_minor_ver, sizeof(fw_api_minor_ver), token);
             if (status != NVM_SUCCESS) {
                 free(fw_api_version);
                 return status;

--- a/src/pmw_utils.c
+++ b/src/pmw_utils.c
@@ -51,19 +51,16 @@ NVM_UINT32
 PMW_UTILS_Strncpy_Safe (
     char       *dst,
     size_t      dst_size,
-    const char *src,
-    size_t      count
+    const char *src
 )
 {
-    size_t to_copy;
-
     if (!dst || !src) {
         fprintf(stderr, "ERROR: NULL value for strncpy operation\n");
 
         return 1;
     }
 
-    to_copy = (count < strlen(src)) ? count : strlen(src);
+    size_t to_copy = strlen(src);
 
     if (to_copy >= dst_size) {
         fprintf(stderr, "ERROR: (strncpy) buffer too small\n");
@@ -71,7 +68,7 @@ PMW_UTILS_Strncpy_Safe (
         return 1;
     }
 
-    strncpy(dst, src, to_copy);
+    memcpy(dst, src, to_copy);
     dst[to_copy] = '\0';
 
     return NVM_SUCCESS;
@@ -81,11 +78,10 @@ NVM_UINT32
 PMW_UTILS_Strncat_Safe(
     char       *dst,
     size_t      dst_size,
-    const char *src,
-    size_t      count
+    const char *src
 )
 {
-    size_t to_copy, len;
+    size_t to_copy, copy_at;
 
     if (!dst || !src) {
         fprintf(stderr, "ERROR: NULL value for strncat operation\n");
@@ -93,18 +89,17 @@ PMW_UTILS_Strncat_Safe(
         return 1;
     }
 
-    to_copy = (count < strlen(src)) ? count : strlen(src);
-    len = to_copy + strlen(dst);
+    to_copy = strlen(src);
+    copy_at = strlen(dst);
 
-    if (len >= dst_size) {
+    if (to_copy + copy_at >= dst_size) {
         fprintf(stderr, "ERROR: (strncat) buffer too small\n");
 
         return 1;
     }
-    else {
-        strncat(dst, src, to_copy);
-        dst[len] = '\0';
-    }
+
+    memcpy(dst + copy_at, src, to_copy);
+    dst[to_copy + copy_at] = '\0';
 
     return NVM_SUCCESS;
 }

--- a/src/pmwatch.c
+++ b/src/pmwatch.c
@@ -92,7 +92,7 @@ pmwatch_parse_cli (
     char      extension[] = ".csv";
     char      file_mode[] = "w";
 
-    ret_val = STRNCPY_SAFE(DELIMITER_M, sizeof(DELIMITER_M), SEMICOLON_M, sizeof(SEMICOLON_M));
+    ret_val = STRNCPY_SAFE(DELIMITER_M, sizeof(DELIMITER_M), SEMICOLON_M);
     if (ret_val != NVM_SUCCESS) {
         return ret_val;
     }
@@ -172,7 +172,7 @@ pmwatch_parse_cli (
                 return NVM_ERR_INVALIDPARAMETER;
             }
 
-            ret_val = STRNCPY_SAFE(file_name, SMALL_STR_LEN, argv[itr + 1], strlen(argv[itr + 1]));
+            ret_val = STRNCPY_SAFE(file_name, SMALL_STR_LEN, argv[itr + 1]);
             if (ret_val != NVM_SUCCESS) {
                 return ret_val;
             }
@@ -185,22 +185,22 @@ pmwatch_parse_cli (
                 return NVM_ERR_INVALIDPARAMETER;
             }
 
-            ret_val = STRNCPY_SAFE(file_name, SMALL_STR_LEN, argv[itr + 1], strlen(argv[itr + 1]));
+            ret_val = STRNCPY_SAFE(file_name, SMALL_STR_LEN, argv[itr + 1]);
             if (ret_val != NVM_SUCCESS) {
                 return ret_val;
             }
-            ret_val = STRNCPY_SAFE(file_mode, sizeof(file_mode), "a", strlen("a"));
+            ret_val = STRNCPY_SAFE(file_mode, sizeof(file_mode), "a");
             if (ret_val != NVM_SUCCESS) {
                 return ret_val;
             }
             file_logging = 1;
         }
         else if (strcmp(argv[itr], "-td") == 0 || strcmp(argv[itr], "--tab-delimited") == 0) {
-            ret_val = STRNCPY_SAFE(extension, sizeof(extension), ".tsv", strlen(".tsv"));
+            ret_val = STRNCPY_SAFE(extension, sizeof(extension), ".tsv");
             if (ret_val != NVM_SUCCESS) {
                 return ret_val;
             }
-            ret_val = STRNCPY_SAFE(DELIMITER_M, sizeof(DELIMITER_M), TAB_M, sizeof(TAB_M));
+            ret_val = STRNCPY_SAFE(DELIMITER_M, sizeof(DELIMITER_M), TAB_M);
             if (ret_val != NVM_SUCCESS) {
                 return ret_val;
             }
@@ -224,7 +224,7 @@ pmwatch_parse_cli (
     // set stdout or fout
     if (file_logging) {
         if (strstr(file_name, ".csv") == NULL) {
-            ret_val = STRNCAT_SAFE(file_name, SMALL_STR_LEN, extension, strlen(extension));
+            ret_val = STRNCAT_SAFE(file_name, SMALL_STR_LEN, extension);
             if (ret_val != NVM_SUCCESS) {
                 return ret_val;
             }


### PR DESCRIPTION
There's a reason no one but MSVC uses those "safe" functions — they're either unsafe or inefficient (for most of those functions, in all cases!).